### PR TITLE
Put values and offsets on the same device on gpu

### DIFF
--- a/merlin/loader/torch.py
+++ b/merlin/loader/torch.py
@@ -135,7 +135,7 @@ class Loader(torch.utils.data.IterableDataset, LoaderBase):
             offsets = torch.arange(values.size()[0], device=self.device)
         num_rows = len(offsets)
         if HAS_GPU:
-            offsets = torch.cat([offsets, torch.cuda.LongTensor([len(values)])])
+            offsets = torch.cat([offsets, torch.cuda.LongTensor([len(values)], device=self.device)])
         else:
             offsets = torch.cat([offsets, torch.LongTensor([len(values)])])
         diff_offsets = offsets[1:] - offsets[:-1]

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,8 @@ commands =
     python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]
+passenv =
+    NR_USER
 sitepackages=true
 ; Runs in: Internal Jenkins
 ; Runs GPU-based tests.


### PR DESCRIPTION
Hot fix for https://github.com/NVIDIA-Merlin/Transformers4Rec/issues/526.

### Implementation
- With sparse tensors, create the tensor for values on the same device as the tensor for offsets.

### Testing
`python -m pytest tests/unit/loader/test_torch_dataloader.py`
Manually tested the [notebook from T4R](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/examples/end-to-end-session-based/03-Session-based-Yoochoose-multigpu-training-PyT.ipynb) as described in https://github.com/NVIDIA-Merlin/Transformers4Rec/issues/526.
Ideally we probably want to set up automated tests for multi-gpu settings but it will probably have to be a follow-up work after the current release.