### PR TITLE
Remove unused `cat_names` and `cont_names` from `LoaderBase`

### DIFF
--- a/merlin/loader/loader_base.py
+++ b/merlin/loader/loader_base.py
@@ -117,8 +117,6 @@ class LoaderBase:
 
         self._epochs = 1
 
-        self.cat_names = dataset.schema.select_by_tag(Tags.CATEGORICAL).column_names
-        self.cont_names = dataset.schema.select_by_tag(Tags.CONTINUOUS).column_names
         self.label_names = dataset.schema.select_by_tag(Tags.TARGET).column_names
 
         if len(list(self.dtype_reverse_map.keys())) == 0:


### PR DESCRIPTION
Remove unused `cat_names` and `cont_names` from `LoaderBase`