### PR TITLE
Use value_count max only for sparse max instead of min == max

### DIFF
--- a/merlin/loader/loader_base.py
+++ b/merlin/loader/loader_base.py
@@ -102,7 +102,7 @@ class LoaderBase:
                 self.sparse_names.append(col_name)
 
                 value_count = col_spec.value_count
-                if value_count and value_count.min == value_count.max:
+                if value_count and value_count.max:
                     self.sparse_max[col_name] = value_count.max
 
                 if not col_spec.is_ragged:

--- a/tests/unit/loader/test_tf_dataloader.py
+++ b/tests/unit/loader/test_tf_dataloader.py
@@ -447,7 +447,7 @@ def test_sparse_tensors(tmpdir, sparse_dense):
         schema[col_name] = schema[col_name].with_tags(Tags.CATEGORICAL)
         if not sparse_dense:
             schema[col_name] = schema[col_name].with_properties(
-                {"value_count": {"min": spa_mx[col_name], "max": spa_mx[col_name]}}
+                {"value_count": {"max": spa_mx[col_name]}}
             )
 
     for col_name in []:

--- a/tests/unit/loader/test_torch_dataloader.py
+++ b/tests/unit/loader/test_torch_dataloader.py
@@ -287,7 +287,7 @@ def test_sparse_tensors(sparse_dense):
     for col_name in spa_lst:
         if not sparse_dense:
             schema[col_name] = schema[col_name].with_properties(
-                {"value_count": {"min": spa_mx[col_name], "max": spa_mx[col_name]}}
+                {"value_count": {"max": spa_mx[col_name]}}
             )
     ds.schema = schema
 


### PR DESCRIPTION
Checking only the `max` value of value count to set the maximum sequence length.

If value count min != max, based on my understanding of what we use the value count to represent (the min and max length of list values in a column). this implies we have a fixed size list column, and so don't need a sparse representation.

This change depends on: https://github.com/NVIDIA-Merlin/core/pull/171