### PR TITLE
Add lint workflow using pre-commit

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -31,9 +31,6 @@ jobs:
     - name: Install and upgrade python packages
       run: |
         python -m pip install --upgrade pip setuptools==59.4.0 wheel tox
-    - name: Lint
-      run: |
-        tox -re lint
     - name: Run unittests
       run: |
         tox -re test-cpu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          cache: 'pip'
+          cache-dependency-path: '**/**.txt'
+      - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v2.14.1
     hooks:
     - id: pylint
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,7 +22,6 @@ disable=fixme,
     # we'll probably never enable these checks
     invalid-name,
     import-error,
-    no-self-use,
 
     # disable code-complexity checks for now
     # TODO: should we configure the thresholds for these rather than just disable?
@@ -36,7 +35,7 @@ disable=fixme,
     too-many-return-statements,
     too-many-lines,
     too-few-public-methods,
-    
+
     # many of these checks would be great to include at some point, but would
     # require some changes to our codebase
     useless-return,
@@ -54,7 +53,7 @@ disable=fixme,
     no-else-raise,
     no-member,
     super-with-arguments,
-    unsupported-assignment-operation, 
+    unsupported-assignment-operation,
     inconsistent-return-statements,
     duplicate-string-formatting-argument,
     len-as-condition,

--- a/merlin/loader/loader_base.py
+++ b/merlin/loader/loader_base.py
@@ -464,7 +464,7 @@ class LoaderBase:
             values, offsets, diff_offsets, num_rows, seq_limit, sparse_as_dense
         )
 
-    def _to_tensor(self, df):
+    def _to_tensor(self, gdf):
         """
         One of the mandatory functions a child class needs
         to implement. Maps from a cudf DataFrame to a

--- a/merlin/loader/torch.py
+++ b/merlin/loader/torch.py
@@ -116,8 +116,8 @@ class Loader(torch.utils.data.IterableDataset, LoaderBase):
             return torch.Tensor(values).type(dtype)
         return from_dlpack(dlpack)
 
-    def _to_tensor(self, df):
-        return self._unpack(self._pack(df))
+    def _to_tensor(self, gdf):
+        return self._unpack(self._pack(gdf))
 
     def _split_fn(self, tensor, idx, axis=0):
         return torch.split(tensor, idx, dim=axis)

--- a/merlin/loader/utils/tf/tf_trainer.py
+++ b/merlin/loader/utils/tf/tf_trainer.py
@@ -140,7 +140,7 @@ def training_step(examples, labels, first_batch):
 for batch, (examples, labels) in enumerate(train_dataset_tf):
     loss_value = training_step(examples, labels, batch == 0)
     if batch % 100 == 0 and hvd.local_rank() == 0:
-        print("Step #%d\tLoss: %.6f" % (batch, loss_value))
+        print(f"Step #{batch}\tLoss: {loss_value:.6f}")
 hvd.join()
 
 # Horovod: save checkpoints only on worker 0 to prevent other workers from

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,22 +2,13 @@ scipy
 scikit-learn>=0.20
 npy_append_array
 
-black==22.3.0
-click<8.1.0
-flake8==3.9.2
 ipython_genutils
-isort==5.9.3
 nbsphinx>=0.6
-pylint==2.7.4
-bandit==1.7.0
-flake8-nb==0.3.0
 pytest>=5
 pytest-cov>=2
 
 moto>=2
 cpplint>=1.5
-codespell
-interrogate==1.5.0
 
 # docs
 Sphinx<3.6
@@ -34,4 +25,4 @@ linkify-it-py<1.1
 
 # needed to avoid bug in sphinx-markdown-tables
 # https://github.com/ryanfox/sphinx-markdown-tables/issues/36
-markdown==3.3.7  
+markdown==3.3.7

--- a/tests/unit/loader/test_tf_dataloader.py
+++ b/tests/unit/loader/test_tf_dataloader.py
@@ -258,7 +258,7 @@ def test_tensorflow_dataloader(
                 rows += num_samples
                 continue
             else:
-                raise ValueError("Batch size too small at idx {}".format(idx))
+                raise ValueError(f"Batch size too small at idx {idx}")
 
         # check that all the features in X have the
         # appropriate length and that the set of

--- a/tox.ini
+++ b/tox.ini
@@ -42,19 +42,6 @@ commands =
 
     python -m pytest --cov-report term --cov merlin -rxs tests/unit
 
-[testenv:lint]
-; Runs in: Github Actions
-; Runs all lint/code checks and fails the PR if there are errors.
-; Install pre-commit-hooks to run these tests during development.
-deps = -rrequirements/dev.txt
-commands =
-    flake8 setup.py merlin/ tests/
-    black --check --diff merlin tests
-    pylint merlin tests
-    isort -c merlin tests --skip .tox
-    interrogate merlin tests --config=pyproject.toml
-    codespell merlin tests --skip .tox
-
 [testenv:docs]
 ; Runs in: Github Actions
 ; Generates documentation with sphinx. There are other steps in the Github Actions workflow

--- a/versioneer.py
+++ b/versioneer.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+# pylint: skip-file
 # Version: 0.23
 
 """The Versioneer - like a rocketeer, but for versions.


### PR DESCRIPTION
## Motivation

Ensure lint checks running locally with pre-commit are consistent with checks in CI.

Using pre-commit for checks in CI and running on all files, we can ensure that the versions checked locally and in CI are the same. 

## Details

Add lint workflow using pre-commit