### PR TITLE
Add yaml linter to check for formatting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
     rev: v1.28.0
     hooks:
       - id: yamllint
-        args: [--format, parsable, --strict]
   # notebooks
   - repo: https://github.com/s-weigand/flake8-nb
     rev: v0.5.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,43 +7,43 @@ repos:
   - repo: https://github.com/timothycrosley/isort
     rev: 5.10.1
     hooks:
-    - id: isort
-      additional_dependencies: [toml]
-      exclude: examples/.*
+      - id: isort
+        additional_dependencies: [toml]
+        exclude: examples/.*
   # code style
   - repo: https://github.com/python/black
     rev: 22.6.0
     hooks:
-    - id: black
+      - id: black
   - repo: https://github.com/pycqa/pylint
     rev: v2.14.1
     hooks:
-    - id: pylint
+      - id: pylint
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
-    - id: flake8
+      - id: flake8
   # notebooks
   - repo: https://github.com/s-weigand/flake8-nb
     rev: v0.5.2
     hooks:
-    - id: flake8-nb
-      files: \.ipynb$
+      - id: flake8-nb
+        files: \.ipynb$
   # documentation
   - repo: https://github.com/econchick/interrogate
     rev: 1.5.0
     hooks:
-    - id: interrogate
-      exclude: ^(docs|examples|tests|setup.py|versioneer.py)
-      args: [--config=pyproject.toml]
+      - id: interrogate
+        exclude: ^(docs|examples|tests|setup.py|versioneer.py)
+        args: [--config=pyproject.toml]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.1
     hooks:
-    - id: codespell
-      exclude: .github/.*
+      - id: codespell
+        exclude: .github/.*
   # security
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
-    - id: bandit
-      args: [--verbose, -ll, -x, tests,examples]
+      - id: bandit
+        args: [--verbose, -ll, -x, tests, examples]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
+        args: [--format, parsable, --strict]
   # notebooks
   - repo: https://github.com/s-weigand/flake8-nb
     rev: v0.5.2

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+---
+extends: default
+
+ignore: |
+    conda/
+
+rules:
+    line-length: disable
+    document-start: disable
+    truthy: disable


### PR DESCRIPTION
## Motivation

Have encountered issues adding new GitHub Actions workflows where it's unclear why a workflow hasn't been detected.

It turns out that this is likely because the file had an invalid formatting and GitHub Actions failed to parse it.

## Details

Adding yamllint to the pre-commit config so that we check formatting at commit time and in CI to ensure there are no formatting errors. And save time in future when adding or changing workflow config