### PR TITLE
fix naming

### DIFF
--- a/examples/01b-Getting-started-Pytorch.ipynb
+++ b/examples/01b-Getting-started-Pytorch.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "# Getting Started with Merlin dataloader and PyTorch\n",
     "\n",
-    "This notebook is created using the latest stable [merlin-tensorflow](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/merlin/containers/merlin-tensorflow) container.\n",
+    "This notebook is created using the latest stable [merlin-pytorch](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/merlin/containers/merlin-pytorch) container.\n",
     "\n",
     "## Overview\n",
     "\n",
@@ -212,7 +212,7 @@
    "id": "daffce3a",
    "metadata": {},
    "source": [
-    "The `ratings.csv` file stores ratings a user has given a movie. Let's load the data directly from disk into a `Merlin Dataset` and train a simple `MatrixFactorization` model that we will construct in `Tensorflow`."
+    "The `ratings.csv` file stores ratings a user has given a movie. Let's load the data directly from disk into a `Merlin Dataset` and train a simple `MatrixFactorization` model that we will construct in `PyTorch`."
    ]
   },
   {


### PR DESCRIPTION
Correct reference to framework in `examples/01b-Getting-started-Pytorch.ipynb`