### PR TITLE
Add `peek` method to get first batch without advancing iterator

### DIFF
--- a/examples/01a-Getting-started-Tensorflow.ipynb
+++ b/examples/01a-Getting-started-Tensorflow.ipynb
@@ -326,7 +326,7 @@
     }
    ],
    "source": [
-    "batch = next(iter(loader))\n",
+    "batch = loader.peek()\n",
     "batch"
    ]
   },

--- a/examples/01b-Getting-started-Pytorch.ipynb
+++ b/examples/01b-Getting-started-Pytorch.ipynb
@@ -292,7 +292,7 @@
     }
    ],
    "source": [
-    "batch = next(iter(loader))\n",
+    "batch = loader.peek()\n",
     "batch"
    ]
   },

--- a/tests/unit/dataloader/test_jax_dataloader.py
+++ b/tests/unit/dataloader/test_jax_dataloader.py
@@ -49,6 +49,6 @@ def test_dataloader_schema(tmpdir, dataset, cpu, num_rows):
         shuffle=False,
     )
 
-    inputs, target = next(iter(data_loader))
+    inputs, target = next(data_loader)
     columns = set(dataset.schema.column_names) - {"label"}
     assert set(inputs) == columns

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -101,7 +101,7 @@ def test_nested_list():
         shuffle=False,
     )
 
-    batch = next(iter(train_dataset))
+    batch = next(train_dataset)
     # [[1,2,3],[3,1],[...],[]]
     nested_data_col = tf.RaggedTensor.from_row_lengths(
         batch[0]["data"][0][:, 0], tf.cast(batch[0]["data"][1][:, 0], tf.int32)
@@ -135,7 +135,7 @@ def test_shuffling():
 
     train_dataset = tf_dataloader.Loader(ds, batch_size=batch_size, shuffle=True)
 
-    batch = next(iter(train_dataset))
+    batch = next(train_dataset)
 
     first_batch = tf.reshape(tf.cast(batch[0]["a"].cpu(), tf.int32), (batch_size,))
     in_order = tf.range(0, batch_size, dtype=tf.int32)
@@ -618,7 +618,7 @@ def test_dataloader_schema(tmpdir, dataset, batch_size, cpu):
         shuffle=False,
     )
 
-    batch = next(iter(data_loader))
+    batch = next(data_loader)
 
     columns = set(dataset.schema.column_names) - {"label"}
     assert set(batch[0]) == columns

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -57,6 +57,17 @@ def test_peek_and_restore():
     assert len(list(xs)) == 3
 
 
+def test_peek():
+    df = make_df({"a": [1, 2, 3]})
+    dataset = Dataset(df)
+    loader = tf_dataloader.Loader(dataset, batch_size=1)
+    first_batch = loader.peek()
+    all_batches = list(loader)
+    test_case = tf.test.TestCase()
+    test_case.assertAllEqual(first_batch, all_batches[0])
+    assert len(all_batches) == 3
+
+
 def test_simple_model():
     df = make_df({"a": [0.1, 0.2, 0.3], "label": [0, 1, 0]})
     dataset = Dataset(df)

--- a/tests/unit/dataloader/test_torch_dataloader.py
+++ b/tests/unit/dataloader/test_torch_dataloader.py
@@ -46,7 +46,7 @@ def test_shuffling():
 
     train_dataset = torch_dataloader.Loader(ds, batch_size=batch_size, shuffle=True)
 
-    batch = next(iter(train_dataset))
+    batch = next(train_dataset)
 
     first_batch = batch[0]["a"].cpu()
     in_order = torch.arange(0, batch_size)
@@ -323,7 +323,7 @@ def test_dataloader_schema(df, dataset, batch_size, cpu):
         shuffle=False,
     )
 
-    X, y = next(iter(data_loader))
+    X, y = next(data_loader)
     columns = set(dataset.schema.column_names) - {"label"}
     assert columns == set(X.keys())
 


### PR DESCRIPTION
Adds a `peek` method to get first batch without advancing iterator.

## Motivation

A common pattern in our notebooks and tests is to fetch the first batch to check or validate something. Following #65 , the loader is now an iterator that is not reset by calling the iter method `iter(loader)`. Some examples and tests were relying on this iter method to reset the loader and check the first batch.

