### PR TITLE
Revert to using Keras Sequence for TensorFlow Loader

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -258,9 +258,6 @@ class LoaderBase:
         generate_local_seed(self.global_rank, self.global_size)
 
     def __iter__(self):
-        if self._batch_itr is not None:
-            return self
-
         self.stop()
         self.num_rows_processed = 0
         if self._buff.stopped:

--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -73,6 +73,10 @@ class Loader(LoaderBase):
     `feature_name: feature_tensor` and each element of the labels
     list is a tensor, and all tensors are of shape `(batch_size, 1)`.
 
+    We're implementing the keras Sequence interface because using the
+    loader as an iterator with keras has a limitation of only being able
+    to run for one epoch.
+
     Parameters
     -------------
     dataset: merlin.io.Dataset
@@ -127,6 +131,31 @@ class Loader(LoaderBase):
             device=device,
         )
         self._map_fns = []
+
+    def __len__(self):
+        """Number of batches in the Sequence.
+
+        Note: This also resets the loader state.
+              Required because of the calls to `__getitem__`
+              from keras prior to the start of the main loop
+              through the loader.
+        """
+        LoaderBase.stop(self)
+        return LoaderBase.__len__(self)
+
+    def __getitem__(self, index):
+        """Gets batch at position `index`.
+
+        Note: This returns the next batch in the iterator.
+              Not the batch at position `index`.
+              This is because the dataloader is implemented as an iterator and
+              don't currently support fetching a batch by index.
+        """
+        return LoaderBase.__next__(self)
+
+    def on_epoch_end(self):
+        "Method called at the end of every epoch."
+        self.stop()
 
     def map(self, fn):
         """

--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -30,7 +30,7 @@ import tensorflow as tf  # noqa
 # pylint: disable=no-value-for-parameter,unexpected-keyword-arg,redundant-keyword-arg
 
 
-class Loader(LoaderBase):
+class Loader(tf.keras.utils.Sequence, LoaderBase):
     """
     Infinite generator used to asynchronously iterate through CSV or Parquet
     dataframes on GPU by leveraging an `merlin.io.Dataset`.

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -52,7 +52,7 @@ def peek_and_restore(x):
 def test_peek_and_restore():
     df = make_df({"a": [1, 2, 3]})
     dataset = Dataset(df)
-    loader = tf_dataloader.Loader(dataset, batch_size=1)
+    loader = tf_dataloader.Loader(dataset, batch_size=1, shuffle=False)
     xs = peek_and_restore(loader)
     assert len(list(xs)) == 3
 
@@ -60,7 +60,7 @@ def test_peek_and_restore():
 def test_peek():
     df = make_df({"a": [1, 2, 3]})
     dataset = Dataset(df)
-    with tf_dataloader.Loader(dataset, batch_size=1) as loader:
+    with tf_dataloader.Loader(dataset, batch_size=1, shuffle=False) as loader:
         first_batch = loader.peek()
         all_batches = list(loader)
     test_case = tf.test.TestCase()

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -80,7 +80,9 @@ def test_simple_model():
     outputs = tf.keras.layers.Dense(1, activation="softmax")(outputs)
     model = tf.keras.Model(inputs=inputs, outputs=outputs)
     model.compile(optimizer="sgd", loss="binary_crossentropy", metrics=["accuracy"])
-    model.fit(loader, epochs=2)
+    history_callback = model.fit(loader, epochs=2, shuffle=False)
+    assert len(history_callback.history["loss"]) == 2
+    assert all(loss > 0.0 for loss in history_callback.history["loss"])
 
     preds_model = model.predict({"a": tf.constant([0.1, 0.2, 0.3])})
     preds_loader = model.predict(loader)

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -15,7 +15,6 @@
 #
 
 import importlib.util
-import itertools
 import os
 import subprocess
 import time
@@ -42,19 +41,6 @@ tf = pytest.importorskip("tensorflow")
 # If tensorflow isn't installed skip these tests. Note that the
 # tf_dataloader import needs to happen after this line
 tf_dataloader = pytest.importorskip("merlin.dataloader.tensorflow")
-
-
-def peek_and_restore(x):
-    peek = next(x)
-    return itertools.chain([peek], x)
-
-
-def test_peek_and_restore():
-    df = make_df({"a": [1, 2, 3]})
-    dataset = Dataset(df)
-    loader = tf_dataloader.Loader(dataset, batch_size=1, shuffle=False)
-    xs = peek_and_restore(loader)
-    assert len(list(xs)) == 3
 
 
 def test_peek():


### PR DESCRIPTION
Revert to using Keras Sequence for TensorFlow Loader. Partial revert of #65 

Using with the generator data adapter seems to only support a single run through the dataset. (1 epoch).

Switching back to the keras sequence for now to preserve existing epoch functionality.