### PR TITLE
Support multiple label columns

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -626,9 +626,14 @@ class LoaderBase:
         # TODO: use dict for labels as well?
         # would require output layers to match naming
         # labels should not exist separately they should be a regular column
-        labels = None
-        if len(self.label_names) > 0:
+        if len(self.label_names) == 0:
+            labels = None
+        elif len(self.label_names) == 1:
             labels = X.pop(self.label_names[0])
+        else:
+            labels = {}
+            for label in self.label_names:
+                labels[label] = X.pop(label)
 
         if self.transforms:
             X = self.executor.transform(DictArray(X), [self.transforms])

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -666,3 +666,31 @@ def test_lazy_dataset_map():
 
     assert map_function_called
     assert elapsed_time_seconds < 1
+
+
+def test_keras_model_with_multiple_label_columns():
+    df = make_df({"a": [0.1, 0.2, 0.3], "label1": [0, 1, 0], "label2": [1, 0, 0]})
+    dataset = Dataset(df)
+    dataset.schema["label1"] = dataset.schema["label1"].with_tags(Tags.TARGET)
+    dataset.schema["label2"] = dataset.schema["label2"].with_tags(Tags.TARGET)
+
+    loader = tf_dataloader.Loader(dataset, batch_size=1)
+
+    inputs = tf.keras.Input(name="a", dtype=tf.float32, shape=(1,))
+    outputs = tf.keras.layers.Dense(16, "relu")(inputs)
+    output_1 = tf.keras.layers.Dense(1, activation="softmax", name="label1")(outputs)
+    output_2 = tf.keras.layers.Dense(5, activation="softmax", name="label2")(outputs)
+    # If we are using a Keras model and dataloader returns multiple labels,
+    # `outputs` keys must match the multiple labels returned by the dataloader.
+    model = tf.keras.Model(inputs=inputs, outputs={"label1": output_1, "label2": output_2})
+    model.compile(optimizer="sgd", loss="binary_crossentropy", metrics=["accuracy"])
+    model.fit(loader, epochs=2)
+
+    preds_model = model.predict({"a": tf.constant([0.1, 0.2, 0.3])})
+    preds_loader = model.predict(loader)
+    assert preds_model["label1"].shape == preds_loader["label1"].shape
+    assert preds_model["label2"].shape == preds_loader["label2"].shape
+
+    metrics = model.evaluate(loader, return_dict=True)
+    assert "label1_accuracy" in metrics
+    assert "label2_accuracy" in metrics


### PR DESCRIPTION
Dataloader currently only returns the first label column if there are multiple **label** columns ([permalink](https://github.com/NVIDIA-Merlin/dataloader/blob/498543d54629216dc09a5854dca4dbeeabcab356/merlin/dataloader/loader_base.py#L626-L631)), but this might be problematic for Merlin Models and Transformers4rec, which expect a dictionary output for the labels when there are multiple labels. This PR implements support for when there are multiple label columns.

Note that Keras expects the name of the output layer to match and users will have to specify the output layer name if there multiple columns. This should not be an issue for Merlin Models.

#### Testing
Additional unit test.
Tested with https://github.com/NVIDIA-Merlin/models/pull/845 (manually with corresponding changes)