### PR TITLE
Remove echo from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     -rrequirements/base.txt
     -rrequirements/dev.txt
 commands = 
-    echo {posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
     python -m pip install -e .[all]
@@ -30,7 +29,6 @@ deps =
     -rrequirements/base.txt
     -rrequirements/dev.txt
 commands =
-    echo {posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
     python -m pip install -e .[tensorflow]
@@ -44,7 +42,6 @@ deps =
     -rrequirements/base.txt
     -rrequirements/dev.txt
 commands =
-    echo {posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
     python -m pip install -e .[torch]
@@ -58,7 +55,6 @@ deps =
     -rrequirements/base.txt
     -rrequirements/dev.txt
 commands =
-    echo {posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
     python -m pip install -e .[jax]


### PR DESCRIPTION
Removes echo command from tox.ini config. 

- This breaks with the recent release of tox 4
- Can be made to work with `allowlist_externals`. However, we don't really need this here since the output of each command is printed