### PR TITLE
Add schema setter to enable changing loader features on Loader instance

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -671,6 +671,12 @@ class LoaderBase:
         ValueError
             When value provided doesn't match expected type
         """
+        if self._working:
+            raise RuntimeError(
+                "Setting the input_schema after the dataloader has started is not supported. "
+                "If you would like to change the input_schema "
+                "please change before reading the first batch. "
+            )
         if not isinstance(value, Schema):
             raise ValueError(
                 "schema value on loader must be of type merlin.io.Schema. "

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -620,8 +620,9 @@ class LoaderBase:
         return gdf.toDlpack()
 
     @property
-    def input_schema(self) -> Schema:
-        """Get schema of data to be loaded
+    def schema(self) -> Schema:
+        """Get input schema of data to be loaded
+
         Returns
         -------
         ~merlin.schema.Schema
@@ -630,12 +631,31 @@ class LoaderBase:
         return self._input_schema
 
     @property
-    def output_schema(self) -> Schema:
-        """Get schema of data to be loaded
+    def input_schema(self) -> Schema:
+        """Get input schema of data to be loaded.
+
+        If there are no transforms then this will be the same as the output schema.
+
         Returns
         -------
         ~merlin.schema.Schema
-            Schema corresponding to the data
+            Schema corresponding to the data that will be loaded  prior to any transforms.
+        """
+        return self._input_schema
+
+    @property
+    def output_schema(self) -> Schema:
+        """Get output schema of data being loaded.
+
+        When there are transforms defined that change the features being loaded,
+        This output schema is intended to account for this and should match
+        the features returned by the loader. If there are no transforms then this
+        will be the same as the input schema.
+
+        Returns
+        -------
+        ~merlin.schema.Schema
+            Schema corresponding to the data that will be output by the loader
         """
         return self._output_schema
 

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -671,7 +671,7 @@ class LoaderBase:
         ValueError
             When value provided doesn't match expected type
         """
-        if self._working:
+        if self._batch_itr is not None:
             raise RuntimeError(
                 "Setting the input_schema after the dataloader has started is not supported. "
                 "If you would like to change the input_schema "

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -628,6 +628,10 @@ class LoaderBase:
         ~merlin.schema.Schema
             Schema corresponding to the data
         """
+        warnings.warn(
+            "This `schema` property is deprecated and will be removed in a future version. "
+            "Please use either the `input_schema` or `output_schema` property instead."
+        )
         return self._input_schema
 
     @property

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -97,6 +97,7 @@ class LoaderBase:
         self._workers = None
 
         self._transforms = None
+        self.executor = None
         self._transform_graph = None
 
         if transforms is not None:
@@ -115,9 +116,6 @@ class LoaderBase:
                 transform_graph = transforms
             self._transform_graph = transform_graph
             self.executor = LocalExecutor()
-        else:
-            self.transforms = None
-            self.executor = None
 
         schema = dataset.schema
         self.input_schema = schema

--- a/merlin/dataloader/ops/embeddings/embedding_op.py
+++ b/merlin/dataloader/ops/embeddings/embedding_op.py
@@ -185,6 +185,7 @@ class NumpyEmbeddingOperator(BaseOperator):
         col_schemas = []
         for _, col_schema in input_schema.column_schemas.items():
             col_schemas.append(col_schema)
+        embedding_dim = self.embeddings.shape[1]
         col_schemas.append(
             ColumnSchema(
                 name=self.embedding_name,
@@ -192,6 +193,7 @@ class NumpyEmbeddingOperator(BaseOperator):
                 dtype=self.embeddings.dtype,
                 is_list=True,
                 is_ragged=False,
+                properties={"value_count": {"min": embedding_dim, "max": embedding_dim}},
             )
         )
 

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -54,6 +54,15 @@ def test_peek():
     assert len(all_batches) == 3
 
 
+def test_set_input_schema():
+    df = make_df({"a": [1, 2, 3], "b": [4, 5, 6]})
+    dataset = Dataset(df)
+    loader = tf_dataloader.Loader(dataset)
+    loader.schema = dataset.schema.excluding_by_name(["b"])
+    x, y = loader.peek()
+    assert set(x.keys()) == {"a"}
+
+
 def test_simple_model():
     df = make_df({"a": [0.1, 0.2, 0.3], "label": [0, 1, 0]})
     dataset = Dataset(df)

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -54,11 +54,11 @@ def test_peek():
     assert len(all_batches) == 3
 
 
-def test_set_change_schema():
+def test_set_change_input_schema():
     df = make_df({"a": [1, 2, 3], "b": [4, 5, 6]})
     dataset = Dataset(df)
     loader = tf_dataloader.Loader(dataset, batch_size=1)
-    loader.schema = dataset.schema.excluding_by_name(["b"])
+    loader.input_schema = dataset.schema.excluding_by_name(["b"])
     x, y = loader.peek()
     assert set(x.keys()) == {"a"}
 

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -54,10 +54,10 @@ def test_peek():
     assert len(all_batches) == 3
 
 
-def test_set_input_schema():
+def test_set_change_schema():
     df = make_df({"a": [1, 2, 3], "b": [4, 5, 6]})
     dataset = Dataset(df)
-    loader = tf_dataloader.Loader(dataset)
+    loader = tf_dataloader.Loader(dataset, batch_size=1)
     loader.schema = dataset.schema.excluding_by_name(["b"])
     x, y = loader.peek()
     assert set(x.keys()) == {"a"}

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -68,7 +68,7 @@ def test_set_input_schema_after_start():
     dataset = Dataset(df)
     loader = tf_dataloader.Loader(dataset, batch_size=1)
     with pytest.raises(RuntimeError) as exc_info:
-        x, y = loader.peek()
+        _ = next(loader)
         loader.input_schema = dataset.schema.excluding_by_name(["b"])
     assert "Setting the input_schema after the dataloader has started is not supported" in str(
         exc_info.value

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -54,13 +54,25 @@ def test_peek():
     assert len(all_batches) == 3
 
 
-def test_set_change_input_schema():
+def test_set_input_schema():
     df = make_df({"a": [1, 2, 3], "b": [4, 5, 6]})
     dataset = Dataset(df)
     loader = tf_dataloader.Loader(dataset, batch_size=1)
     loader.input_schema = dataset.schema.excluding_by_name(["b"])
     x, y = loader.peek()
     assert set(x.keys()) == {"a"}
+
+
+def test_set_input_schema_after_start():
+    df = make_df({"a": [1, 2, 3], "b": [4, 5, 6]})
+    dataset = Dataset(df)
+    loader = tf_dataloader.Loader(dataset, batch_size=1)
+    with pytest.raises(RuntimeError) as exc_info:
+        x, y = loader.peek()
+        loader.input_schema = dataset.schema.excluding_by_name(["b"])
+    assert "Setting the input_schema after the dataloader has started is not supported" in str(
+        exc_info.value
+    )
 
 
 def test_simple_model():

--- a/tests/unit/dataloader/test_tf_embeddings.py
+++ b/tests/unit/dataloader/test_tf_embeddings.py
@@ -59,6 +59,14 @@ def test_embedding_tf_np_mmap_dl_no_lookup(tmpdir, embedding_ids, np_embeddings_
         shuffle=False,
         device=cpu,
     )
+
+    assert data_loader.input_schema.column_names == ["id"]
+    assert data_loader.output_schema.column_names == ["id", "embeddings"]
+
+    embeddings_dim = 1024
+    embeddings_value_count = data_loader.output_schema["embeddings"].value_count
+    assert embeddings_value_count.min == embeddings_value_count.max == embeddings_dim
+
     full_len = 0
     for idx, batch in enumerate(data_loader):
         assert "embeddings" in batch[0]


### PR DESCRIPTION
- Adds schema properties
  - `input_schema`, `output_schema`
  - And setter for the `input_schema` so that `Loader.input_schema = <new_schema>` can be used to change the features that are loaded.

## Motivation

In Merlin Models https://github.com/NVIDIA-Merlin/models/pull/904 would like to be able to automatically detect the case where a loader constructed that will load more features than required by the model. And enable us to update the loader instance to only  load the required features