### PR TITLE
Split CPU tests and building packages into separate Github Actions

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -41,44 +41,6 @@ jobs:
             branch=${raw/origin\/}
           fi
           tox -e test-cpu -- $branch
-      - name: Generate package for pypi
-        run: |
-          python setup.py sdist
-      - name: Upload pypi artifacts to github
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-      - name: Generate package for conda
-        id: conda_build
-        run: |
-          echo "conda pkgs dir $CONDA_PKGS_DIRS"
-          conda update conda
-          conda install -c conda-forge mamba
-          mamba install -c conda-forge conda-build boa
-          conda mambabuild . -c defaults -c conda-forge -c numba -c rapidsai -c nvidia --output-folder ./conda_packages
-          export CONDA_PACKAGE=$(find ./conda_packages/ -name merlin-dataloader*.tar.bz2)
-          echo "conda_package : $CONDA_PACKAGE"
-          echo "conda_package=$CONDA_PACKAGE" >> $GITHUB_OUTPUT
-      - name: Upload conda artifacts to github
-        uses: actions/upload-artifact@v3
-        with:
-          name: conda
-          path: ${{ steps.conda_build.outputs.conda_package }}
-      # Build docs, treat warnings as errors
-      - name: Building docs
-        run: |
-          tox -re docs
-      - name: Upload HTML
-        uses: actions/upload-artifact@v3
-        with:
-          name: html-build-artifact
-          path: docs/build/html
-          if-no-files-found: error
-          retention-days: 1
       - name: Store PR information
         run: |
           mkdir ./pr
@@ -90,46 +52,3 @@ jobs:
         with:
           name: pr
           path: pr/
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [build]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist
-      - name: Create GitHub Release
-        uses: fnkr/github-action-ghr@v1.3
-        env:
-          GHR_PATH: ./dist
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Push to PyPi
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          pip install --upgrade wheel pip setuptools twine
-          twine upload dist/*
-      - uses: actions/download-artifact@v3
-        with:
-          name: conda
-          path: conda
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-      - name: Install conda dependencies
-        shell: bash -l {0}
-        run: |
-          conda install -y anaconda-client conda-build
-      - name: Push to anaconda
-        shell: bash -l {0}
-        env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: |
-          anaconda -t $ANACONDA_TOKEN upload -u nvidia conda/*.tar.bz2

--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -1,0 +1,125 @@
+name: CPU CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    tags:
+      - v*
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-packages:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.9]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get update -y
+      - name: Install and upgrade python packages
+        run: |
+          python -m pip install --upgrade pip setuptools==59.4.0 wheel tox
+      - name: Generate package for pypi
+        run: |
+          python setup.py sdist
+      - name: Upload pypi artifacts to github
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+      - name: Generate package for conda
+        id: conda_build
+        run: |
+          echo "conda pkgs dir $CONDA_PKGS_DIRS"
+          conda update conda
+          conda install -c conda-forge mamba
+          mamba install -c conda-forge conda-build boa
+          conda mambabuild . -c defaults -c conda-forge -c numba -c rapidsai -c nvidia --output-folder ./conda_packages
+          export CONDA_PACKAGE=$(find ./conda_packages/ -name merlin-dataloader*.tar.bz2)
+          echo "conda_package : $CONDA_PACKAGE"
+          echo "conda_package=$CONDA_PACKAGE" >> $GITHUB_OUTPUT
+      - name: Upload conda artifacts to github
+        uses: actions/upload-artifact@v3
+        with:
+          name: conda
+          path: ${{ steps.conda_build.outputs.conda_package }}
+      # Build docs, treat warnings as errors
+      - name: Building docs
+        run: |
+          tox -re docs
+      - name: Upload HTML
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-build-artifact
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 1
+      - name: Store PR information
+        run: |
+          mkdir ./pr
+          echo ${{ github.event.number }}              > ./pr/pr.txt
+          echo ${{ github.event.pull_request.merged }} > ./pr/merged.txt
+          echo ${{ github.event.action }}              > ./pr/action.txt
+      - name: Upload PR information
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: Create GitHub Release
+        uses: fnkr/github-action-ghr@v1.3
+        env:
+          GHR_PATH: ./dist
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Push to PyPi
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install --upgrade wheel pip setuptools twine
+          twine upload dist/*
+      - uses: actions/download-artifact@v3
+        with:
+          name: conda
+          path: conda
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+      - name: Install conda dependencies
+        shell: bash -l {0}
+        run: |
+          conda install -y anaconda-client conda-build
+      - name: Push to anaconda
+        shell: bash -l {0}
+        env:
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: |
+          anaconda -t $ANACONDA_TOKEN upload -u nvidia conda/*.tar.bz2


### PR DESCRIPTION
Building conda packages isn't currently working, which needs a fix but shouldn't block us from merging PRs. Splitting the CPU tests and the package building into separate actions should unblock some WIP.