### PR TITLE
Update Dataloader for `ColumnSchema` API changes from Merlin Core

### DIFF
--- a/merlin/dataloader/ops/embeddings/embedding_op.py
+++ b/merlin/dataloader/ops/embeddings/embedding_op.py
@@ -108,8 +108,7 @@ class EmbeddingOperator(BaseOperator):
                 name=self.embedding_name,
                 tags=[Tags.CONTINUOUS],
                 dtype=self._get_dtype(self.embeddings),
-                is_list=True,
-                is_ragged=False,
+                properties={"is_list": True, "is_ragged": False},
             )
         )
 
@@ -191,9 +190,11 @@ class NumpyEmbeddingOperator(BaseOperator):
                 name=self.embedding_name,
                 tags=[Tags.CONTINUOUS],
                 dtype=self.embeddings.dtype,
-                is_list=True,
-                is_ragged=False,
-                properties={"value_count": {"min": embedding_dim, "max": embedding_dim}},
+                properties={
+                    "is_list": True,
+                    "is_ragged": False,
+                    "value_count": {"min": embedding_dim, "max": embedding_dim},
+                },
             )
         )
 


### PR DESCRIPTION
Since `is_list` and `is_ragged` have become derived properties computed from the shape, it's no longer possible to directly set them from the constructor. They can be smuggled in through the properties, after which they'll be used to determine an appropriate shape that results in the same `is_list` and `is_ragged` values on the other side.

(This is a first step toward capturing and using more comprehensive shape information, with the goal of putting `Shape` in place while breaking as little as possible. There will be subsequent changes to directly capture more shape information, but this gets us part-way there.)

Depends on https://github.com/NVIDIA-Merlin/core/pull/195