### PR TITLE
fix gpu visibility on docker

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ commands =
 [testenv:test-gpu]
 passenv =
     NR_USER
+    CUDA_VISIBLE_DEVICES
 sitepackages=true
 ; Runs in: Internal Jenkins
 ; Runs GPU-based tests.


### PR DESCRIPTION
This PR ensures that any environment restrictions set on the GPU visibility are passed down to the tox environment executing the unit test run.