### PR TITLE
Restore support for passing `device` in CPU-only environment

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -74,10 +74,8 @@ class LoaderBase:
         self.global_rank = global_rank or 0
         self.drop_last = drop_last
 
-        if device:
-            self.device = device
-        else:
-            self.device = "cpu" if not HAS_GPU or dataset.cpu else 0
+        device = device or 0
+        self.device = "cpu" if not HAS_GPU or dataset.cpu else device
 
         if self.device == "cpu":
             self._array_lib = np

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -98,6 +98,11 @@ def test_simple_model():
     _ = model.evaluate(loader)
 
 
+def test_with_device():
+    dataset = Dataset(make_df({"a": [1]}))
+    tf_dataloader.Loader(dataset, batch_size=1, device=1).peek()
+
+
 def test_nested_list():
     num_rows = 100
     batch_size = 12


### PR DESCRIPTION
The last PR #104 changed the way the array lib was configured based on the device configured. This assumed that the device would always be set to `"cpu"` in a CPU-only environment (where cupy was not installed).

This PR updates the logic setting the `device` attribute of the loader so that it's always set to `"cpu"` if there is no GPU available or if the dataset is on CPU.