### PR TITLE
Correct cpu-packages config

### DIFF
--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -85,7 +85,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [build]
+    needs: [build-packages]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -1,4 +1,4 @@
-name: CPU CI
+name: Packages
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ on:
     branches: [main]
 
 jobs:
-  build-packages:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -85,7 +85,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [build-packages]
+    needs: [build]
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Correct cpu-packages workflow configuration. The incorrect job reference results in the workflow being skipped.