### PR TITLE
Return Dense Tensors for Fixed List Columns

### DIFF
--- a/merlin/dataloader/jax.py
+++ b/merlin/dataloader/jax.py
@@ -76,24 +76,20 @@ class Loader(LoaderBase):
         if gdf.empty:
             return
 
+        transpose = False
+
         # checks necessary because of this bug
         # https://github.com/tensorflow/tensorflow/issues/42660
         # same logic as in TF dataloader
         if len(gdf.shape) == 1 or gdf.shape[1] == 1:
             dlpack = self._pack(gdf)
-        elif gdf.shape[0] == 1:
-            dlpack = self._pack(gdf.values[0])
         else:
+            transpose = True
             dlpack = self._pack(gdf.values.T)
 
         x = self._unpack(dlpack)
 
-        if gdf.shape[0] == 1 and len(x.shape) != 2:
-            # batch size 1 so got squashed to a vector
-            x = x.reshape((1, x.shape[0]))
-        elif len(gdf.shape) == 1 or len(x.shape) == 1:
-            x = x.reshape((x.shape[0], 1))
-        elif gdf.shape[1] > 1:
+        if transpose:
             x = x.T
 
         return x

--- a/merlin/dataloader/jax.py
+++ b/merlin/dataloader/jax.py
@@ -94,18 +94,6 @@ class Loader(LoaderBase):
 
         return x
 
-    def _pack(self, gdf):
-        if isinstance(gdf, np.ndarray):
-            return gdf
-        elif hasattr(gdf, "to_dlpack") and callable(getattr(gdf, "to_dlpack")):
-            return gdf.to_dlpack()
-        elif hasattr(gdf, "to_numpy") and callable(getattr(gdf, "to_numpy")):
-            gdf = gdf.to_numpy()
-            if isinstance(gdf[0], list):
-                gdf = np.stack(gdf)
-            return gdf
-        return gdf.toDlpack()
-
     def _unpack(self, gdf):
         if hasattr(gdf, "shape"):
             return jax.device_put(gdf)

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -533,10 +533,13 @@ class LoaderBase:
         elif hasattr(gdf, "to_dlpack") and callable(getattr(gdf, "to_dlpack")) and not self.device:
             return gdf.to_dlpack()
         elif hasattr(gdf, "to_numpy") and callable(getattr(gdf, "to_numpy")):
-            gdf = gdf.to_numpy()
-            if isinstance(gdf[0], list):
-                gdf = np.stack(gdf)
-            return gdf
+            if hasattr(gdf, "columns") and len(gdf.columns) == 1:
+                values = gdf[gdf.columns[0]].to_numpy()
+            else:
+                values = gdf.to_numpy()
+            if isinstance(values[0], list):
+                values = np.stack(values)
+            return values
         return gdf.toDlpack()
 
     @property

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -485,10 +485,6 @@ class LoaderBase:
                 for column_name, column_value in zip(k, values):
                     X[column_name] = self._reshape_dim(column_value)
             else:
-                if isinstance(v, tuple):
-                    v = tuple(self._reshape_dim(tv) for tv in v)
-                else:
-                    v = self._reshape_dim(v)
                 X[k] = v
 
         X = ungroup_values_offsets(X)

--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -215,8 +215,6 @@ class Loader(tf.keras.utils.Sequence, LoaderBase):
         # https://github.com/tensorflow/tensorflow/issues/42660
         if len(gdf.shape) == 1 or gdf.shape[1] == 1:
             dlpack = self._pack(gdf)
-        elif gdf.shape[0] == 1:
-            dlpack = self._pack(gdf.values[0])
         else:
             transpose = True
             dlpack = self._pack(gdf.values.T)
@@ -228,11 +226,6 @@ class Loader(tf.keras.utils.Sequence, LoaderBase):
         except AssertionError:
             tf.random.uniform((1,))
             x = self._unpack(dlpack)
-
-        # if rank is already two it is  already in list format
-        if gdf.shape[0] == 1 and not tf.rank(x) == 2:
-            # batch size 1 so got squashed to a vector
-            x = tf.expand_dims(x, 0)
 
         if transpose:
             # matrix which means we had to transpose

--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -210,6 +210,7 @@ class Loader(tf.keras.utils.Sequence, LoaderBase):
         if gdf.empty:
             return
 
+        transpose = False
         # checks necessary because of this bug
         # https://github.com/tensorflow/tensorflow/issues/42660
         if len(gdf.shape) == 1 or gdf.shape[1] == 1:
@@ -217,6 +218,7 @@ class Loader(tf.keras.utils.Sequence, LoaderBase):
         elif gdf.shape[0] == 1:
             dlpack = self._pack(gdf.values[0])
         else:
+            transpose = True
             dlpack = self._pack(gdf.values.T)
 
         # catch error caused by tf eager context
@@ -226,19 +228,17 @@ class Loader(tf.keras.utils.Sequence, LoaderBase):
         except AssertionError:
             tf.random.uniform((1,))
             x = self._unpack(dlpack)
+
         # if rank is already two it is  already in list format
         if gdf.shape[0] == 1 and not tf.rank(x) == 2:
             # batch size 1 so got squashed to a vector
             x = tf.expand_dims(x, 0)
-        elif len(gdf.shape) == 1 or len(x.shape) == 1:
-            # sort of a generic check for any other
-            # len(shape)==1 case, could probably
-            # be more specific
-            x = tf.expand_dims(x, -1)
-        elif gdf.shape[1] > 1:
+
+        if transpose:
             # matrix which means we had to transpose
             # for the bug above, so untranspose
             x = tf.transpose(x)
+
         return x
 
     def _sum(self, tensor):

--- a/merlin/dataloader/torch.py
+++ b/merlin/dataloader/torch.py
@@ -120,8 +120,6 @@ class Loader(torch.utils.data.IterableDataset, LoaderBase):
             values = torch.Tensor(values).type(dtype)
         else:
             values = from_dlpack(dlpack)
-        if len(values.shape) <= 1:
-            values = values.view(-1, 1)
         return values
 
     def _to_tensor(self, gdf):

--- a/tests/unit/dataloader/test_jax_dataloader.py
+++ b/tests/unit/dataloader/test_jax_dataloader.py
@@ -17,7 +17,8 @@
 import numpy as np
 import pytest
 
-from merlin.core.dispatch import HAS_GPU, make_df
+from merlin.core.compat import cupy, HAS_GPU
+from merlin.core.dispatch import make_df, random_uniform
 from merlin.io import Dataset
 from merlin.schema import Tags
 
@@ -25,6 +26,30 @@ pytestmark = pytest.mark.jax
 
 jax = pytest.importorskip("jax")
 jax_dataloader = pytest.importorskip("merlin.dataloader.jax")
+
+
+@pytest.mark.parametrize("element_shape", [(), (1,), (2,), (3, 4)])
+@pytest.mark.parametrize("num_cols", [1, 2])
+def test_fixed_column(element_shape, num_cols):
+    num_rows = 4
+    batch_size = 3
+    df = make_df({
+        f"col{i}": random_uniform(size=(num_rows, *element_shape)).tolist()
+        for i in range(num_cols)
+    })
+
+    dataset = Dataset(df)
+    for col in dataset.schema:
+        dataset.schema[col.name] = dataset.schema[col.name].with_shape((None, *element_shape))
+
+    loader = jax_dataloader.Loader(dataset, batch_size=batch_size)
+    batches = [batch for batch in loader]
+
+    for tensor in batches[0][0].values():
+        assert tensor.shape == (batch_size, *element_shape)
+
+    for tensor in batches[1][0].values():
+        assert tensor.shape == (1, *element_shape)
 
 
 @pytest.mark.parametrize("num_rows", [1000, 10000])

--- a/tests/unit/dataloader/test_torch_dataloader.py
+++ b/tests/unit/dataloader/test_torch_dataloader.py
@@ -23,7 +23,8 @@ import pytest
 from conftest import assert_eq
 
 from merlin.core import dispatch
-from merlin.core.dispatch import HAS_GPU, make_df
+from merlin.core.dispatch import make_df
+from merlin.core.compat import HAS_GPU, cupy
 from merlin.io import Dataset
 from merlin.schema import Tags
 
@@ -33,6 +34,30 @@ pytestmark = pytest.mark.torch
 # torch_dataloader import needs to happen after this line
 torch = pytest.importorskip("torch")
 import merlin.dataloader.torch as torch_dataloader  # noqa isort:skip
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (2,), (3, 4)])
+@pytest.mark.parametrize("num_cols", [1, 2])
+def test_fixed_column(shape, num_cols):
+    num_rows = 4
+    batch_size = 3
+    df = make_df({
+        f"col{i}": dispatch.random_uniform(size=(num_rows, *shape)).tolist()
+        for i in range(num_cols)
+    })
+
+    dataset = Dataset(df)
+    for col in dataset.schema:
+        dataset.schema[col.name] = dataset.schema[col.name].with_shape((None, *shape))
+
+    loader = torch_dataloader.Loader(dataset, batch_size=batch_size)
+    batches = [batch for batch in loader]
+
+    for tensor in batches[0][0].values():
+        assert tensor.shape == (batch_size, *shape)
+
+    for tensor in batches[1][0].values():
+        assert tensor.shape == (1, *shape)
 
 
 def test_shuffling():


### PR DESCRIPTION
## Change to Output Type 

Columns that have fixed shapes will return fixed size dense tensors/arrays instead of the ragged representation.

## Motivation 

- Load Fixed List Columns more quickly. 
- Return type matches data and schema (when we have a fixed size (non-ragged) column)

By handling the special case of fixed list features where the lists are all of the same length, we can bypass some of the slower code that handles ragged lists and load these features more quickly.

