### PR TITLE
Put row lengths on the same device on gpu

### DIFF
--- a/merlin/dataloader/torch.py
+++ b/merlin/dataloader/torch.py
@@ -138,10 +138,10 @@ class Loader(torch.utils.data.IterableDataset, LoaderBase):
         return tensor.sum()
 
     def _row_lengths_to_offsets(self, row_lengths):
-        zero_value = torch.tensor([0], device=self.device, dtype=row_lengths.dtype)
+        zero_value = torch.tensor([0], device=row_lengths.device, dtype=row_lengths.dtype)
         if len(row_lengths.shape) == 2:
             zero_value = zero_value.view(-1, 1)
-        return torch.cat((zero_value, torch.cumsum(row_lengths, 0).to(device=self.device)))
+        return torch.cat((zero_value, torch.cumsum(row_lengths, 0)))
 
     def _process_batch(self, tensors):
         to_return = super()._process_batch(tensors)

--- a/merlin/dataloader/torch.py
+++ b/merlin/dataloader/torch.py
@@ -141,7 +141,7 @@ class Loader(torch.utils.data.IterableDataset, LoaderBase):
         zero_value = torch.tensor([0], device=self.device, dtype=row_lengths.dtype)
         if len(row_lengths.shape) == 2:
             zero_value = zero_value.view(-1, 1)
-        return torch.cat((zero_value, torch.cumsum(row_lengths, 0)))
+        return torch.cat((zero_value, torch.cumsum(row_lengths, 0).to(device=self.device)))
 
     def _process_batch(self, tensors):
         to_return = super()._process_batch(tensors)

--- a/tests/unit/dataloader/test_torch_dataloader.py
+++ b/tests/unit/dataloader/test_torch_dataloader.py
@@ -418,3 +418,9 @@ def test_offsets():
                 feature_tensor = list(feats[col].cpu().numpy())
                 feature_result = results[i][col]
                 assert feature_tensor == feature_result
+
+
+def test_row_lengths_to_offsets_device():
+    dataset = Dataset(make_df({"a": [1]}))
+    loader = torch_dataloader.Loader(dataset, batch_size=1)
+    loader._row_lengths_to_offsets(torch.tensor([1, 2, 3], device=1))

--- a/tests/unit/dataloader/test_torch_dataloader.py
+++ b/tests/unit/dataloader/test_torch_dataloader.py
@@ -420,7 +420,8 @@ def test_offsets():
                 assert feature_tensor == feature_result
 
 
-def test_row_lengths_to_offsets_device():
+@pytest.mark.parametrize("device", ["cpu", 0, 1] if HAS_GPU else ["cpu"])
+def test_row_lengths_to_offsets_device(device):
     dataset = Dataset(make_df({"a": [1]}))
     loader = torch_dataloader.Loader(dataset, batch_size=1)
-    loader._row_lengths_to_offsets(torch.tensor([1, 2, 3], device=1))
+    loader._row_lengths_to_offsets(torch.tensor([1, 2, 3], device=device))


### PR DESCRIPTION
In a multi-gpu setting, tensors may be generated on different devices. This PR forces `torch.cumsum(row_lengths, 0)` to be on the same device as the `zero_value` tensor. If they are on different devices, `torch.cat()` can't concatenate them, e.g.,
```
  File "/usr/local/lib/python3.8/dist-packages/merlin/dataloader/torch.py", line 169, in _row_lengths_to_offsets
    return torch.cat((zero_value, torch.cumsum(row_lengths, 0)))
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cpu! (when checking argument for argument tensors in method wrapper_cat)
```