### PR TITLE
Change row lengths unit tests to use cpu and single gpu

### DIFF
--- a/tests/unit/dataloader/test_torch_dataloader.py
+++ b/tests/unit/dataloader/test_torch_dataloader.py
@@ -420,7 +420,7 @@ def test_offsets():
                 assert feature_tensor == feature_result
 
 
-@pytest.mark.parametrize("device", ["cpu", 0, 1] if HAS_GPU else ["cpu"])
+@pytest.mark.parametrize("device", ["cpu", 0] if HAS_GPU else ["cpu"])
 def test_row_lengths_to_offsets_device(device):
     dataset = Dataset(make_df({"a": [1]}))
     loader = torch_dataloader.Loader(dataset, batch_size=1)


### PR DESCRIPTION
Follow-up to #113.

This updates `test_row_lengths_to_offsets_device` to only test cpu <-> cuda:0 and removes the cpu <-> cuda:1 case because the test will fail if we only have a single GPU. We simply remove the second gpu case because testing the cpu <-> cuda:0 case should be sufficient for testing if the tensor concatenation works across devices.