### PR TITLE
Remove reshape to speed up loading of scalar features in TensorFlow

### DIFF
--- a/merlin/dataloader/jax.py
+++ b/merlin/dataloader/jax.py
@@ -111,6 +111,3 @@ class Loader(LoaderBase):
         if len(row_lengths.shape) == 2:
             zero_value = zero_value.reshape(-1, 1)
         return jnp.concatenate([zero_value, jnp.cumsum(row_lengths, axis=0)], axis=0)
-
-    def _reshape_dim(self, tensor):
-        return jax.numpy.reshape(tensor, (-1,))

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -464,9 +464,7 @@ class LoaderBase:
                 # split out cols and change all scalars
                 # should always return dict column_name: values, offsets (optional)
                 for column_name in column_names:
-                    tensors_by_name[column_name] = self._unpack(
-                        self._pack(gdf_i[column_name].values)
-                    )
+                    tensors_by_name[column_name] = self._to_tensor(gdf_i[[column_name]])
 
             if lists:
                 # split out lists

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -463,9 +463,10 @@ class LoaderBase:
             if scalars:
                 # split out cols and change all scalars
                 # should always return dict column_name: values, offsets (optional)
-                scalars = self._to_tensor(gdf_i[scalars])
-                tensor_key = tuple(column_names) if len(column_names) > 1 else column_names[0]
-                tensors_by_name[tensor_key] = scalars
+                for column_name in column_names:
+                    tensors_by_name[column_name] = self._unpack(
+                        self._pack(gdf_i[column_name].values)
+                    )
 
             if lists:
                 # split out lists
@@ -505,16 +506,7 @@ class LoaderBase:
 
     @annotate("_process_batch", color="darkgreen", domain="merlin_dataloader")
     def _process_batch(self, tensors):
-        X = {}
-        for k, v in tensors.items():
-            if isinstance(k, tuple):
-                values = self._tensor_split(v, len(k), axis=1)
-                for column_name, column_value in zip(k, values):
-                    X[column_name] = self._reshape_dim(column_value)
-            else:
-                X[k] = v
-
-        X = ungroup_values_offsets(X)
+        X = ungroup_values_offsets(tensors)
 
         # Return a tensor if we have only one label column, but return a
         # dictionary of tensors if there are multiple label columns, since

--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -257,9 +257,6 @@ class Loader(tf.keras.utils.Sequence, LoaderBase):
         """
         return dtype.as_numpy_dtype()
 
-    def _reshape_dim(self, tensor):
-        return tf.reshape(tensor, shape=[-1])
-
 
 class KerasSequenceValidater(tf.keras.callbacks.Callback):
     # TODO: document

--- a/merlin/dataloader/torch.py
+++ b/merlin/dataloader/torch.py
@@ -131,9 +131,6 @@ class Loader(torch.utils.data.IterableDataset, LoaderBase):
     def _tensor_split(self, tensor, idx, axis=0):
         return torch.tensor_split(tensor, idx, axis=axis)
 
-    def _reshape_dim(self, tensor):
-        return tensor.view(-1)
-
     def _sum(self, tensor):
         return tensor.sum()
 


### PR DESCRIPTION
**Goal** Improve loading time of TensorFlow dataloader with scalar features. 

## Details

Removing the `_reshape_dim` method. This was required because we grouped scalar columns with the same dtype together during conversion in `_process_dataframe` and then needed to extract the columns into the flat values later in `_process_batch`. This PR removes the need for the reshape later by processing each column separately, like we do for the list columns.

## Timing

```python
import random
import time

import cupy
import cudf

from merlin.io import Dataset


def get_dataset(num_rows, *, num_list_features=0, num_int_features=0, num_float_features=0):    
    list_features = {
        f"list_{i}": [[random.randint(1, 10) for _ in range(4)] for _ in range(num_rows)]
        for i in range(num_list_features)
    }
    scalar_int_features = {
        f"scalar_int_{i}": cupy.random.randint(1, 10, size=num_rows)
        for i in range(num_int_features)
    }
    scalar_float_features = {
        f"scalar_int_{i}": cupy.random.uniform(size=num_rows)
        for i in range(num_float_features)
    }
    features = {**list_features, **scalar_int_features, **scalar_float_features}
    df = cudf.DataFrame(features)
    return  Dataset(df)


def dataset_load_time(dataset, loader_cls, batch_size):
    with loader_cls(dataset, batch_size=batch_size) as loader:
        start_t = time.time()
        for batch in loader:
            pass
        end_t = time.time()
        return end_t - start_t
```

```python
num_rows = 100_000
num_features = 10
dataset = get_dataset(num_rows, num_int_features=num_features)
batch_size = 10
```

### TensorFlow

```python
from merlin.dataloader.tensorflow import Loader as  TFLoader

%timeit -n 10 dataset_load_time(dataset, TFLoader, batch_size=batch_size)
```

- **Before**  `12.7 s ± 44 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
  - Note that this was a performance regression that is only present in the current unreleased development branch
  - _23.02_ - `386 ms ± 2.25 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
- **After** `222 ms ± 2.76 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`

### PyTorch

```python
from merlin.dataloader.torch import Loader as  TorchLoader

%timeit -n 10 dataset_load_time(dataset, TorchLoader, batch_size=batch_size)
```

- **Before** `386 ms ± 3.18 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
- **After** `152 ms ± 1.75 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
