### PR TITLE
replace dictarray for tensortable in transforms functionality

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -731,7 +731,7 @@ class ChunkQueue:
             chunks.reset_index(drop=True, inplace=True)
             chunks, spill = self.get_batch_div_chunk(chunks, self.dataloader.batch_size)
             if self.shuffle:
-                chunks = shuffle_df(chunks)
+                chunks = shuffle_df(chunks, keep_index=True)
 
             if len(chunks) > 0:
                 chunks = self.dataloader.make_tensors(chunks, self.dataloader._use_row_lengths)

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -39,10 +39,11 @@ from merlin.core.dispatch import (
     make_df,
     pull_apart_list,
 )
-from merlin.dag import BaseOperator, ColumnSelector, DictArray, Graph, Node, ungroup_values_offsets
+from merlin.dag import BaseOperator, ColumnSelector, Graph, Node, ungroup_values_offsets
 from merlin.dag.executors import LocalExecutor
 from merlin.io import shuffle_df
 from merlin.schema import Schema, Tags
+from merlin.table import TensorTable
 
 try:
     import cudf
@@ -522,7 +523,7 @@ class LoaderBase:
                 labels[label] = X.pop(label)
 
         if self.transforms:
-            X = self.executor.transform(DictArray(X), [self.transforms])
+            X = self.executor.transform(TensorTable(X), [self.transforms])
 
         return X, labels
 

--- a/merlin/dataloader/ops/embeddings/embedding_op.py
+++ b/merlin/dataloader/ops/embeddings/embedding_op.py
@@ -56,7 +56,7 @@ class EmbeddingOperator(BaseOperator):
         self, col_selector: ColumnSelector, transformable: Transformable
     ) -> Transformable:
         keys = transformable[self.lookup_key]
-        indices = keys.cpu()
+        indices = keys.cpu().values
         if self.id_lookup_table is not None:
             indices = self._create_tensor(np.nonzero(np.in1d(self.id_lookup_table, indices)))
         embeddings = self._embeddings_lookup(indices)
@@ -149,7 +149,7 @@ class NumpyEmbeddingOperator(BaseOperator):
         self, col_selector: ColumnSelector, transformable: Transformable
     ) -> Transformable:
         keys = transformable[self.lookup_key]
-        indices = keys.cpu()
+        indices = keys.cpu().values
         if self.id_lookup_table is not None:
             indices = np.in1d(self.id_lookup_table, indices)
         embeddings = self.embeddings[indices]
@@ -200,7 +200,7 @@ class NumpyEmbeddingOperator(BaseOperator):
         return Schema(col_schemas)
 
 
-class MmapNumpyTorchEmbedding(NumpyEmbeddingOperator):
+class MmapNumpyEmbedding(NumpyEmbeddingOperator):
     """Operator loads numpy embedding table from file using memory map to be used to create
     torch embedding representations. This allows for larger than host memory embedding
     tables to be used for embedding lookups. The only limit to the size is what fits in

--- a/merlin/dataloader/ops/embeddings/tf_embedding_op.py
+++ b/merlin/dataloader/ops/embeddings/tf_embedding_op.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 
 from merlin.dataloader.ops.embeddings.embedding_op import (
     EmbeddingOperator,
-    MmapNumpyTorchEmbedding,
+    MmapNumpyEmbedding,
     NumpyEmbeddingOperator,
 )
 
@@ -77,7 +77,7 @@ class TF_NumpyEmbeddingOperator(NumpyEmbeddingOperator):
         return tf.squeeze(tf.convert_to_tensor(embeddings))
 
 
-class TF_MmapNumpyTorchEmbedding(MmapNumpyTorchEmbedding):
+class TF_MmapNumpyEmbedding(MmapNumpyEmbedding):
     """Operator loads numpy embedding table from file using memory map to be used to create
     tensorflow embedding representations. This allows for larger than host memory embedding
     tables to be used for embedding lookups. The only limit to the size is what fits in

--- a/merlin/dataloader/ops/embeddings/torch_embedding_op.py
+++ b/merlin/dataloader/ops/embeddings/torch_embedding_op.py
@@ -19,7 +19,7 @@ from torch.nn import Embedding
 
 from merlin.dataloader.ops.embeddings.embedding_op import (
     EmbeddingOperator,
-    MmapNumpyTorchEmbedding,
+    MmapNumpyEmbedding,
     NumpyEmbeddingOperator,
 )
 
@@ -55,7 +55,7 @@ class TorchEmbeddingOperator(EmbeddingOperator):
         return self.embeddings(indices)
 
     def _format_embeddings(self, embeddings, keys):
-        return torch.squeeze(embeddings.to(keys.device))
+        return torch.squeeze(embeddings.to(keys.values.device))
 
     def _get_dtype(self, embeddings):
         return embeddings.weight.numpy().dtype
@@ -79,10 +79,10 @@ class Torch_NumpyEmbeddingOperator(NumpyEmbeddingOperator):
     """
 
     def _format_embeddings(self, embeddings, keys):
-        return torch.from_numpy(embeddings).to(keys.device)
+        return torch.from_numpy(embeddings).to(keys.values.device)
 
 
-class Torch_MmapNumpyTorchEmbedding(MmapNumpyTorchEmbedding):
+class Torch_MmapNumpyTorchEmbedding(MmapNumpyEmbedding):
     """Operator loads numpy embedding table from file using memory map to be used to create
     torch embedding representations. This allows for larger than host memory embedding
     tables to be used for embedding lookups. The only limit to the size is what fits in
@@ -103,4 +103,4 @@ class Torch_MmapNumpyTorchEmbedding(MmapNumpyTorchEmbedding):
     """
 
     def _format_embeddings(self, embeddings, keys):
-        return torch.from_numpy(embeddings).to(keys.device)
+        return torch.from_numpy(embeddings).to(keys.values.device)

--- a/tests/unit/dataloader/test_tf_embeddings.py
+++ b/tests/unit/dataloader/test_tf_embeddings.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.tensorflow
 tf = pytest.importorskip("tensorflow")
 
 from merlin.dataloader.ops.embeddings.tf_embedding_op import (  # noqa
-    TF_MmapNumpyTorchEmbedding,
+    TF_MmapNumpyEmbedding,
     TF_NumpyEmbeddingOperator,
     TFEmbeddingOperator,
 )
@@ -55,7 +55,7 @@ def test_embedding_tf_np_mmap_dl_no_lookup(tmpdir, embedding_ids, np_embeddings_
     data_loader = Loader(
         dataset,
         batch_size=batch_size,
-        transforms=[TF_MmapNumpyTorchEmbedding(embeddings_file)],
+        transforms=[TF_MmapNumpyEmbedding(embeddings_file)],
         shuffle=False,
         device=cpu,
     )
@@ -72,9 +72,9 @@ def test_embedding_tf_np_mmap_dl_no_lookup(tmpdir, embedding_ids, np_embeddings_
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -100,7 +100,7 @@ def test_embedding_tf_np_mmap_dl_with_lookup(tmpdir, rev_embedding_ids, np_embed
     data_loader = Loader(
         dataset,
         batch_size=batch_size,
-        transforms=[TF_MmapNumpyTorchEmbedding(embeddings_file, ids_lookup_npz=id_lookup_file)],
+        transforms=[TF_MmapNumpyEmbedding(embeddings_file, ids_lookup_npz=id_lookup_file)],
         shuffle=False,
         device=cpu,
     )
@@ -109,9 +109,9 @@ def test_embedding_tf_np_mmap_dl_with_lookup(tmpdir, rev_embedding_ids, np_embed
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -146,9 +146,9 @@ def test_embedding_tf_np_dl_no_lookup(tmpdir, embedding_ids, embeddings_from_dat
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings_np[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings_np[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -186,9 +186,9 @@ def test_embedding_tf_np_dl_with_lookup(tmpdir, rev_embedding_ids, embeddings_fr
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings_np[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings_np[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -224,9 +224,9 @@ def test_embedding_tf_dl_no_lookup(tmpdir, embedding_ids, embeddings_from_datafr
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == np_tensor[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == np_tensor[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -263,7 +263,7 @@ def test_embedding_tf_dl_with_lookup(tmpdir, rev_embedding_ids, embeddings_from_
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == np_tensor[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == np_tensor[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]

--- a/tests/unit/dataloader/test_torch_embeddings.py
+++ b/tests/unit/dataloader/test_torch_embeddings.py
@@ -63,9 +63,9 @@ def test_embedding_torch_np_mmap_dl_with_lookup(
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == rev_embedding_ids.shape[0]
 
 
@@ -96,9 +96,9 @@ def test_embedding_torch_np_mmap_dl_no_lookup(tmpdir, embedding_ids, np_embeddin
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -134,9 +134,9 @@ def test_embedding_torch_np_dl_with_lookup(
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings_df[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings_df[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -167,9 +167,9 @@ def test_embedding_torch_np_dl_no_lookup(tmpdir, embedding_ids, embeddings_from_
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == embeddings_df[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == embeddings_df[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -202,9 +202,9 @@ def test_embedding_torch_dl_with_lookup(tmpdir, rev_embedding_ids, embeddings_fr
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == np_tensor[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == np_tensor[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]
 
 
@@ -236,7 +236,7 @@ def test_embedding_torch_dl_no_lookup(tmpdir, embedding_ids, embeddings_from_dat
         assert "embeddings" in batch[0]
         assert "id" in batch[0]
         start = idx * batch_size
-        end = start + batch[0]["id"].shape[0]
-        assert (batch[0]["embeddings"].cpu().numpy() == np_tensor[start:end]).all()
-        full_len += batch[0]["embeddings"].shape[0]
+        end = start + int(batch[0]["id"].shape[0])
+        assert (batch[0]["embeddings"].cpu().values.numpy() == np_tensor[start:end]).all()
+        full_len += int(batch[0]["embeddings"].shape[0])
     assert full_len == embedding_ids.shape[0]


### PR DESCRIPTION
This PR replaces the use of dictarray with tensortable so that now the embedding operators work against tensortables.