### PR TITLE
Remove reset of dataloader in len method of `ArrayLoader`

### DIFF
--- a/merlin/dataloader/array.py
+++ b/merlin/dataloader/array.py
@@ -214,14 +214,7 @@ class ArrayLoader(ArrayLoaderBase):
             return np
 
     def __len__(self):
-        """Number of batches in the Sequence.
-
-        Note: This also resets the loader state.
-              Required because of the calls to `__getitem__`
-              from keras prior to the start of the main loop
-              through the loader.
-        """
-        ArrayLoaderBase.stop(self)
+        """Number of batches in the dataloader."""
         return ArrayLoaderBase.__len__(self)
 
     def __getitem__(self, index):

--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -56,6 +56,17 @@ class Loader(ArrayLoader, tf.keras.utils.Sequence):
             convert_col, _to_dlpack_fn=_to_dlpack_fn, _from_dlpack_fn=_from_dlpack_fn, _unsafe=True
         )
 
+    def __len__(self):
+        """Number of batches in the Sequence.
+
+        Note: This also resets the loader state.
+              Required because of the calls to `__getitem__`
+              from keras prior to the start of the main loop
+              through the loader.
+        """
+        ArrayLoader.stop(self)
+        return ArrayLoader.__len__(self)
+
     def __getitem__(self, index):
         """Gets batch at position `index`.
 


### PR DESCRIPTION
Following #111 removing the reset of the dataloader (call to the `stop` method) inside the `__len__` method of `ArrayLoader`.

This loader reset in the len method caused some infinte loops in Transformers4Rec where we call len on the dataloader during it's iteration in an `evaluation_loop` method of the trainer.