### PR TITLE
fixing imports for tf and torch in dataloader

### DIFF
--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -15,7 +15,7 @@
 #
 from functools import partial
 
-from merlin.core.compat import tensorflow as tf
+from merlin.core.compat.tensorflow import tensorflow as tf
 from merlin.dataloader.loader_base import LoaderBase
 from merlin.table import TensorColumn, TensorflowColumn, TensorTable
 from merlin.table.conversions import _dispatch_dlpack_fns, convert_col

--- a/merlin/dataloader/torch.py
+++ b/merlin/dataloader/torch.py
@@ -15,7 +15,7 @@
 #
 from functools import partial
 
-from merlin.core.compat import torch as th
+from merlin.core.compat.torch import torch as th
 from merlin.dataloader.loader_base import LoaderBase
 from merlin.table import TensorColumn, TensorTable, TorchColumn
 from merlin.table.conversions import _dispatch_dlpack_fns, convert_col

--- a/tests/unit/dataloader/test_array_to_tensorflow.py
+++ b/tests/unit/dataloader/test_array_to_tensorflow.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from merlin.core.compat import tensorflow as tf
+from merlin.core.compat.tensorflow import tensorflow as tf
 from merlin.core.dispatch import make_df
 from merlin.io import Dataset
 from merlin.schema import Tags

--- a/tests/unit/dataloader/test_array_to_torch.py
+++ b/tests/unit/dataloader/test_array_to_torch.py
@@ -15,7 +15,7 @@
 #
 import pytest
 
-from merlin.core.compat import torch as th
+from merlin.core.compat.torch import torch as th
 from merlin.core.dispatch import make_df
 from merlin.io import Dataset
 from merlin.schema import Tags


### PR DESCRIPTION
This PR works in tandem with https://github.com/NVIDIA-Merlin/core/pull/272. This fixes imports from core compat after the core pr is merged.