### PR TITLE
Apply map function when peeking in tensorflow

### DIFF
--- a/merlin/dataloader/tensorflow.py
+++ b/merlin/dataloader/tensorflow.py
@@ -88,7 +88,11 @@ class Loader(LoaderBase, tf.keras.utils.Sequence):
     def peek(self):
         """Grab the next batch from the dataloader
         without removing it from the queue"""
-        return self.convert_batch(self._peek_next_batch())
+        converted_batch = self.convert_batch(self._peek_next_batch())
+        for map_fn in self._map_fns:
+            converted_batch = map_fn(*converted_batch)
+
+        return converted_batch
 
     def on_epoch_end(self):
         self.stop()

--- a/tests/unit/dataloader/test_tf_dataloader.py
+++ b/tests/unit/dataloader/test_tf_dataloader.py
@@ -74,6 +74,21 @@ def test_peek():
     assert len(all_batches) == 3
 
 
+def test_peek_map():
+    inputs = make_df({"a": [1, 999, 999]})
+    dataset = Dataset(inputs)
+
+    def _map_fn(x_in, y_in):
+        x_out = make_df({"b": [42]})
+        y_out = make_df({"c": [43]})
+        return x_out, y_out
+
+    with tf_loader(dataset, batch_size=1, shuffle=False).map(_map_fn) as loader:
+        x, y = loader.peek()
+    assert set(x.keys()) == {"b"}
+    assert set(y.keys()) == {"c"}
+
+
 def test_set_input_schema():
     df = make_df({"a": [1, 2, 3], "b": [[4], [5, 6], [7]]})
     dataset = Dataset(df)


### PR DESCRIPTION
`.peek()` is supposed to produce the same output as `next()` without advancing the iterator:
https://github.com/NVIDIA-Merlin/dataloader/blob/699ca7b0e72e921752da2a31b5bfb9764c9cf2ee/merlin/dataloader/tensorflow.py#L80-L86
but the `.map()` functionality in `peek()` got dropped after the recent dataloader changes, while `__next__` still applies the map function properly. This PR applies the same logic currently in `__next__` to `peek()`. Models currently makes use of this combination: `map()` and `peek()`.