### PR TITLE
Revert "Set device for torch tensors with gpu > 1 (#132)"

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -447,8 +447,7 @@ class LoaderBase:
         if self.device == "cpu":
             tensor = df_or_series.to_numpy()
         else:
-            with cupy.cuda.Device(self.device):
-                tensor = df_or_series.to_cupy()
+            tensor = df_or_series.to_cupy()
 
         return tensor
 

--- a/merlin/dataloader/torch.py
+++ b/merlin/dataloader/torch.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import contextlib
 from functools import partial
 
 from merlin.core.compat.torch import torch as th
@@ -118,11 +117,6 @@ class Loader(LoaderBase, th.utils.data.IterableDataset):
         self._map_fns.append(fn)
 
         return self
-
-    def _get_device_ctx(self, dev):
-        if dev == "cpu" or not th:
-            return contextlib.nullcontext()
-        return th.cuda.device(f"cuda:{dev}")
 
 
 class DLDataLoader(th.utils.data.DataLoader):


### PR DESCRIPTION
This reverts commit 8782c9d6c10c56de57607e06b1b1dd6a4e9b6430 (which fixed #131).

Setting the device via the cupy API causes [horovod (2GPU) tests](https://github.com/NVIDIA-Merlin/models/blob/572a7b4d05eb2d471ac1621b5bce1d8dc9729bdb/tox.ini#L51) to hang with:
```
[1,1]<stdout>:merlin/models/tf/models/base.py:1387: in fit                                                                                                                          
[1,1]<stdout>:    out = super().fit(**fit_kwargs)                                                                                                                                   
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/keras/utils/traceback_utils.py:70: in error_handler                                                                            
[1,1]<stdout>:    raise e.with_traceback(filtered_tb) from None                                                                                                                     
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/tensorflow.py:78: in __getitem__                                                                             
[1,1]<stdout>:    return self.__next__()                                                                                                                                            
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/tensorflow.py:82: in __next__                                                                                
[1,1]<stdout>:    converted_batch = self.convert_batch(super().__next__())                                                                                                          
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/loader_base.py:261: in __next__                                                                              
[1,1]<stdout>:    return self._get_next_batch()                                                                                                                                     
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/loader_base.py:332: in _get_next_batch                                                                       
[1,1]<stdout>:    batch = next(self._batch_itr)                                                                                                                                     
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/loader_base.py:369: in make_tensors                                                                          
[1,1]<stdout>:    tensors_by_name = self._convert_df_to_tensors(gdf)                                                                                                                
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/nvtx/nvtx.py:101: in inner                                                                                                     
[1,1]<stdout>:    result = func(*args, **kwargs)                                                                                                                                    
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/loader_base.py:524: in _convert_df_to_tensors                                                                
[1,1]<stdout>:    tensors_by_name[column_name] = self._to_tensor(gdf_i[[column_name]])                                                                                              
[1,1]<stdout>:/usr/local/lib/python3.8/dist-packages/merlin/dataloader/loader_base.py:453: in _to_tensor                                                                            
[1,1]<stdout>:    with cupy.cuda.Device(self.device):                                                                                                                               
[1,1]<stdout>:cupy/cuda/device.pyx:184: in cupy.cuda.device.Device.__enter__                                                                                                        
[1,1]<stdout>:    ???                                                                                                                                                               
[1,1]<stdout>:cupy_backends/cuda/api/runtime.pyx:365: in cupy_backends.cuda.api.runtime.setDevice                                                                                   
[1,1]<stdout>:    ???                                                                                                                                                               
[1,1]<stdout>:_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
_ _ _ _ _ _ _                                                                                                                                                                       
[1,1]<stdout>:                                                                                                                                                                      
[1,1]<stdout>:>   ???                                                                                                                                                               
[1,1]<stdout>:E   cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorInvalidDevice: invalid device ordinal                                                                   
[1,1]<stdout>:                                                                                                                                                                      
[1,1]<stdout>:cupy_backends/cuda/api/runtime.pyx:142: CUDARuntimeError                                                                                                              
```