### PR TITLE
Enable transforms to work when targets are output from dataloader

### DIFF
--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -575,7 +575,7 @@ class LoaderBase:
                 labels[label] = X.pop(label)
 
         if self.transforms:
-            X = self.executor.transform(TensorTable(X), [self.transforms])
+            X = self.executor.transform(TensorTable(X), [self.transforms]).to_dict()
 
         return X, labels
 

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -575,7 +575,7 @@ class LoaderBase:
                 labels[label] = X.pop(label)
 
         if self.transforms:
-            X = self.executor.transform(TensorTable(X), [self.transforms]).to_dict()
+            X = self.executor.transform(TensorTable(X), [self.transforms])
 
         return X, labels
 

--- a/merlin/dataloader/loader_base.py
+++ b/merlin/dataloader/loader_base.py
@@ -666,7 +666,7 @@ class LoaderBase:
 
         if self._transform_graph is not None:
             self._transforms = self._transform_graph.construct_schema(
-                self._input_schema
+                self._input_schema.excluding_by_tag(Tags.TARGET)
             ).output_node
             self._output_schema = self._transforms.output_schema
         else:

--- a/tests/unit/dataloader/test_embeddings.py
+++ b/tests/unit/dataloader/test_embeddings.py
@@ -58,7 +58,7 @@ def test_embedding_with_target():
     assert x["id"].values.shape == (2,)
     assert x["id_embedding"].values.shape == (2, 10)
     assert data_loader.output_schema.column_names == ["id", "id_embedding"]
-    np.testing.assert_array_equal(y, np.array([0, 1]))
+    assert y.tolist() == [0, 1]
 
 
 @pytest.mark.parametrize("cpu", [None, "cpu"] if HAS_GPU else ["cpu"])

--- a/tests/unit/dataloader/test_embeddings.py
+++ b/tests/unit/dataloader/test_embeddings.py
@@ -55,9 +55,8 @@ def test_embedding_with_target():
         shuffle=False,
     )
     x, y = data_loader.peek()
-    assert isinstance(x, dict)
-    assert x["id"].shape == (2,)
-    assert x["id_embedding"].shape == (2, 10)
+    assert x["id"].values.shape == (2,)
+    assert x["id_embedding"].values.shape == (2, 10)
     assert data_loader.output_schema.column_names == ["id", "id_embedding"]
     np.testing.assert_array_equal(y, np.array([0, 1]))
 


### PR DESCRIPTION
Enable transforms to work when targets are output from dataloader.

Fixes one of the issues @bschifferer reported in this comment https://github.com/NVIDIA-Merlin/Merlin/issues/211#issuecomment-1514680251

Adds test for EmbeddingOperator when used with targets. This currently raises a KeyError because the graph was constructed with all columns including targets. However, we don't pass targets to the transforms.