### PR TITLE
fix array dl tests gpu vs cpu

### DIFF
--- a/tests/unit/dataloader/test_array_dataloader.py
+++ b/tests/unit/dataloader/test_array_dataloader.py
@@ -51,4 +51,7 @@ def test_dataloader(tmpdir, dataset, cpu, num_rows):
         for col in columns:
             start = idx * int(num_rows / 10)
             end = start + int(num_rows / 10)
-            assert np.all(batch[0][col].ravel() == df[col].iloc[start:end])
+            if cpu:
+                assert np.all(batch[0][col].ravel() == df[col].iloc[start:end].to_numpy())
+            else:
+                assert np.all(batch[0][col].ravel() == df[col].iloc[start:end])


### PR DESCRIPTION
this PR fixes issues with tests where they are producing the right values but not in the correct format. This effects later versions of cudf (23.2.0) and pandas (1.5.3). So we need to account for that. This is required for the 23.04 containers.