### PR TITLE
Update requirements for Merlin packages to minimum version of 23.04

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -27,9 +27,7 @@ requirements:
     - setuptools
   run:
     - python
-    {% for req in setup_py_data.get('install_requires', []) %}
-    - {{ req }}
-    {% endfor %}
+    - merlin-core>=23.04.00
 
 about:
   home: https://github.com/NVIDIA-Merlin/dataloader

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -27,7 +27,9 @@ requirements:
     - setuptools
   run:
     - python
-    - merlin-core>=23.04.00
+    {% for req in setup_py_data.get('install_requires', []) %}
+    - {{ req }}
+    {% endfor %}
 
 about:
   home: https://github.com/NVIDIA-Merlin/dataloader

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-merlin-core>=0.8.0
+merlin-core>=23.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-merlin-core>=23.4.0
+merlin-core>=23.04.00


### PR DESCRIPTION
Update requirements for Merlin Core package to minimum version of 23.04. This contains features required for the upcoming release.

Depends on merlin-core 23.4.0 package publish