### PR TITLE
update workflow on which docs pr preview depends

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -2,7 +2,7 @@ name: docs-preview-pr
 
 on:
   workflow_run:
-    workflows: [CPU CI]
+    workflows: [Packages]
     types: [completed]
 
 env:


### PR DESCRIPTION
This should fix the broken documentation preview action. We'll know it's successful if the docs preview link shows up as a comment on this PR.