### PR TITLE
Remove use of deprecated numpy aliases of builtin types

### DIFF
--- a/tests/unit/dataloader/test_torch_dataloader.py
+++ b/tests/unit/dataloader/test_torch_dataloader.py
@@ -176,9 +176,9 @@ def test_gpu_file_iterator_ds(df, dataset, batch):
 
 json_sample = {
     "conts": {
-        "cont_1": {"dtype": np.float, "min_val": 0, "max_val": 1},
-        "cont_2": {"dtype": np.float, "min_val": 0, "max_val": 1},
-        "cont_3": {"dtype": np.float, "min_val": 0, "max_val": 1},
+        "cont_1": {"dtype": float, "min_val": 0, "max_val": 1},
+        "cont_2": {"dtype": float, "min_val": 0, "max_val": 1},
+        "cont_3": {"dtype": float, "min_val": 0, "max_val": 1},
     },
     "cats": {
         "cat_1": {


### PR DESCRIPTION
Fixes AttributeError raised by newer versions of numpy when using `np.float`

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Remove use of deprecated numpy aliases of builtin types

More info here:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
