### PR TITLE
Use Dictionary lookup for supplied IDs to Embedding Operator

### DIFF
--- a/merlin/dataloader/ops/embeddings.py
+++ b/merlin/dataloader/ops/embeddings.py
@@ -43,7 +43,7 @@ class EmbeddingOperator(BaseOperator):
     mmap : bool, default False
         When loading embeddings from a file, specify whether we should memory map the file
         This is useful for accessing a large file without reading the entire file into memory.
-    unknown_value : Union[int, np.ndarray]
+    unknown_value : Union[float, int, np.ndarray]
         If an embedding index is not found.
         Specifies the value should we return for the corresponding embedding.
     """
@@ -55,7 +55,7 @@ class EmbeddingOperator(BaseOperator):
         embedding_name: str = "embeddings",
         id_lookup_table: Optional[Union[np.ndarray, str]] = None,
         mmap: bool = False,
-        unknown_value: Union[int, np.ndarray] = 0,
+        unknown_value: Union[float, int, np.ndarray] = 0,
     ):
         if isinstance(embeddings, (str, os.PathLike)):
             mmap_mode = "r" if mmap else None

--- a/merlin/dataloader/ops/embeddings.py
+++ b/merlin/dataloader/ops/embeddings.py
@@ -70,9 +70,9 @@ class EmbeddingOperator(BaseOperator):
                 "or a (string or pathlike object corresponding to a numpy file) "
                 "containing embeddings. "
             )
-
         self.embeddings = embeddings
 
+        embedding_index_mapping = None
         if isinstance(id_lookup_table, (str, os.PathLike)):
             _ids = np.load(id_lookup_table)
             embedding_index_mapping = self._get_embedding_index_mapping(_ids)
@@ -89,10 +89,10 @@ class EmbeddingOperator(BaseOperator):
                 "or a (string or pathlike object corresponding to a numpy file) "
                 "containing the IDs that correspond to the embeddings. "
             )
+        self.embedding_index_mapping = embedding_index_mapping
 
         self.lookup_key = lookup_key
         self.embedding_name = embedding_name
-        self.embedding_index_mapping = embedding_index_mapping
         self.unknown_value = unknown_value
 
     def _get_embedding_index_mapping(self, ids):

--- a/tests/unit/dataloader/test_embeddings.py
+++ b/tests/unit/dataloader/test_embeddings.py
@@ -40,7 +40,7 @@ def test_embeddings_invalid_ids():
             embedding_name="id_embedding",
             id_lookup_table=ids,
         )
-    assert "ids provided must match the number of embeddings" in str(exc_info.value)
+    assert "IDs provided must match the number of embeddings" in str(exc_info.value)
     assert "Expected IDs with shape (3,)" in str(exc_info.value)
 
 

--- a/tests/unit/dataloader/test_embeddings.py
+++ b/tests/unit/dataloader/test_embeddings.py
@@ -156,7 +156,7 @@ def test_embedding_np_mmap_dl_with_lookup(tmpdir, rev_embedding_ids, np_embeddin
     dataset = dataset.repartition(10)
     schema = dataset.schema
     for col_name in cat_names:
-        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL, Tags.EMBEDDING])
+        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL])
     dataset.schema = schema
 
     data_loader = Loader(
@@ -188,7 +188,7 @@ def test_embedding_np_dl_no_lookup(tmpdir, embedding_ids, embeddings_from_datafr
     dataset = dataset.repartition(10)
     schema = dataset.schema
     for col_name in cat_names:
-        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL, Tags.EMBEDDING])
+        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL])
     dataset.schema = schema
     paths = sorted(glob.glob(f"{embeddings_from_dataframe}/*"))
     embeddings_ds = Dataset(paths)
@@ -223,7 +223,7 @@ def test_embedding_np_dl_with_lookup(tmpdir, rev_embedding_ids, embeddings_from_
     dataset = dataset.repartition(10)
     schema = dataset.schema
     for col_name in cat_names:
-        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL, Tags.EMBEDDING])
+        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL])
     dataset.schema = schema
     paths = sorted(glob.glob(f"{embeddings_from_dataframe}/*"))
     embeddings_ds = Dataset(paths)
@@ -262,7 +262,7 @@ def test_embedding_np_dl_with_lookup_ragged(
     dataset = dataset.repartition(10)
     schema = dataset.schema
     for col_name in cat_names:
-        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL, Tags.EMBEDDING])
+        schema[col_name] = schema[col_name].with_tags([Tags.CATEGORICAL])
     dataset.schema = schema
     paths = sorted(glob.glob(f"{embeddings_from_dataframe}/*"))
     embeddings_ds = Dataset(paths)

--- a/tests/unit/dataloader/test_embeddings.py
+++ b/tests/unit/dataloader/test_embeddings.py
@@ -231,7 +231,9 @@ def test_embedding_np_dl_with_lookup(tmpdir, rev_embedding_ids, embeddings_from_
     data_loader = Loader(
         dataset,
         batch_size=batch_size,
-        transforms=[EmbeddingOperator(embeddings_np, id_lookup_table=embedding_ids.to_numpy())],
+        transforms=[
+            EmbeddingOperator(embeddings_np, id_lookup_table=embedding_ids.to_numpy().ravel())
+        ],
         shuffle=False,
         device=cpu,
     )

--- a/tests/unit/dataloader/test_embeddings.py
+++ b/tests/unit/dataloader/test_embeddings.py
@@ -30,6 +30,20 @@ from merlin.schema.tags import TagSet
 from merlin.table import TensorColumn, TensorTable
 
 
+def test_embeddings_invalid_ids():
+    ids = np.array(["a", "b"])
+    embeddings = np.random.rand(3, 10)
+    with pytest.raises(AssertionError) as exc_info:
+        EmbeddingOperator(
+            embeddings,
+            lookup_key="id",
+            embedding_name="id_embedding",
+            id_lookup_table=ids,
+        )
+    assert "ids provided must match the number of embeddings" in str(exc_info.value)
+    assert "Expected IDs with shape (3,)" in str(exc_info.value)
+
+
 @pytest.mark.parametrize("unknown_value", [0, 1, np.random.uniform(size=10)])
 def test_embedding_lookup_with_unknown_value(unknown_value):
     ids = np.array(["a", "b", "c"])


### PR DESCRIPTION
- Use Dictionary lookup for supplied IDs to Embedding Operator.
- - Improving the speed of index lookups for larger sets of embeddings.
- Adds `unknown_value` option enable unknown IDs to set a default the value for the embedding returned for ids that are not found in the set of pre-trained embeddings
-  Changes the use of the `mmap` parameter to make it optional when passing a file. Currently if passing a file without mmap=True, we get an unrelated error.

### Example

Using 10 million IDs. The operator transform runs in roughly 500-600 milliseonds. This scales proportionaly with the number of IDs.

After this change the operator transform runs in 50-60 microseconds with 10 million IDs.
 