### PR TITLE
Install dependencies in downstream tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -90,9 +90,9 @@ commands =
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/models.git models-{env:GIT_COMMIT}
     python -m pip install --upgrade "./models-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./models-{env:GIT_COMMIT}/requirements/test.txt"
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
-    python -m pip install --no-deps .
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
+    python -m pip install .
     python -m pytest models-{env:GIT_COMMIT}/tests/unit
 
 [testenv:test-nvtabular-cpu]
@@ -103,9 +103,9 @@ commands =
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/NVTabular.git nvtabular-{env:GIT_COMMIT}
     python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./nvtabular-{env:GIT_COMMIT}/requirements/test.txt"
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/models.git@{posargs:main}
-    python -m pip install --no-deps .
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git@{posargs:main}
+    python -m pip install .
     python -m pytest nvtabular-{env:GIT_COMMIT}/tests/unit
 
 [testenv:test-systems-cpu]
@@ -116,10 +116,10 @@ commands =
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/systems.git systems-{env:GIT_COMMIT}
     python -m pip install --upgrade "./systems-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./systems-{env:GIT_COMMIT}/requirements/test-cpu.txt"
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/models.git@{posargs:main}
-    python -m pip install --no-deps .
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git@{posargs:main}
+    python -m pip install .
     python -m pytest -m "not notebook" systems-{env:GIT_COMMIT}/tests/unit
 
 [testenv:test-transformers4rec-cpu]
@@ -130,10 +130,10 @@ commands =
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/Transformers4Rec.git t4r-{env:GIT_COMMIT}
     python -m pip install --upgrade "./t4r-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./t4r-{env:GIT_COMMIT}/requirements/test.txt"
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/models.git@{posargs:main}
-    python -m pip install --no-deps .
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git@{posargs:main}
+    python -m pip install .
     python -m pytest t4r-{env:GIT_COMMIT}/tests/unit
 
 [testenv:docs]


### PR DESCRIPTION
Downstream tests (e.g., `models`, `nvtabular`, etc.) in the CI are failing because dataloader now requires `npy_append_array`. Sample log from [this recent job](https://github.com/NVIDIA-Merlin/dataloader/actions/runs/5171823540/jobs/9315581617?pr=151):
```
models-03d4d83471d591d8ae205a9dff74e0e735dc364e/tests/conftest.py:26: in <module>
    from merlin.datasets.synthetic import generate_data
models-03d4d83471d591d8ae205a9dff74e0e[735](https://github.com/NVIDIA-Merlin/dataloader/actions/runs/5171823543/jobs/9315581663?pr=151#step:6:736)dc364e/merlin/datasets/synthetic.py:26: in <module>
    import merlin.io
.tox/test-models-cpu/lib/python3.9/site-packages/merlin/io/__init__.py:18: in <module>
    from merlin.io import dataframe_iter, dataset, shuffle
.tox/test-models-cpu/lib/python3.9/site-packages/merlin/io/dataset.py:33: in <module>
    from npy_append_array import NpyAppendArray
E   ModuleNotFoundError: No module named 'npy_append_array'
```
but the libraries are pip-installed with `--no-deps` so dependencies are not installed. This PR fixes the downstream tests.